### PR TITLE
PHP 8.0 curly braces syntax

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -92,7 +92,7 @@ class syntax_plugin_box extends DokuWiki_Syntax_Plugin {
 
             case DOKU_LEXER_EXIT:
                 $data = trim(substr($match, 5, -1));
-                $title =  ($data && $data{0} == "|") ? substr($data,1) : '';
+                $title =  ($data && $data[0] == "|") ? substr($data,1) : '';
 
                 return array('box_close', $title);
 


### PR DESCRIPTION
fixes PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /lib/plugins/box/syntax.php on line 95