### PR TITLE
Fix deprecated _addCall method for DokuWiki 2025 compatibility

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -99,7 +99,7 @@ class syntax_plugin_box extends DokuWiki_Syntax_Plugin
                 }
 
             case DOKU_LEXER_UNMATCHED:
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 return false;
 
             case DOKU_LEXER_EXIT:


### PR DESCRIPTION
Replace deprecated Doku_Handler::_addCall() with addCall() method
in syntax.php to resolve deprecation warnings in DokuWiki 2025-05-14a
"Librarian" release.

- Updated line 102 in syntax.php
- Maintains full functionality while ensuring forward compatibility
- Eliminates all deprecation warnings related to _addCall usage